### PR TITLE
color.new optimisations

### DIFF
--- a/src/color.luau
+++ b/src/color.luau
@@ -52,16 +52,11 @@ local color = {}
 <em>Creates a new RGBA </em><code>Color</code><em>.</em>
   ]=]
 function color.new(r: number?, g: number?, b: number?, a: number?): types.Color
-    r = r or 0
-    g = g or 0
-    b = b or 0
-    a = a or 255
-
     return bit32bor(
-        bit32lshift(a, 24),
-        bit32lshift(b, 16),
-        bit32lshift(g, 8),
-        r
+        if a then a * (2^24) else 255 * (2^24),
+        if b then b * (2^16) else 0,
+        if g then g * (2^8) else 0,
+        r or 0
     )
 end
 


### PR DESCRIPTION
2^x is constant folded if x is a constant
multiplication is faster than shifting if the shift amount is known beforehand prevents shifting for g,b, or a if they are blank (255 * 2^24 is constant folded)